### PR TITLE
Health Check utility

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,4 +1,3 @@
-# This docker-compose is only for local
 services:
   sonarqube_db:
     image: bitnami/postgresql:16
@@ -12,7 +11,7 @@ services:
       - sonarqube_db:/bitnami/postgresql
 
   sonarqube:
-    image: adrianmusante/sonarqube:9
+    image: adrianmusante/sonarqube # Recommended to specify a tag with a major or minor version (e.g., 10 or 10.6)
     container_name: sonarqube
     depends_on:
       - sonarqube_db
@@ -28,6 +27,15 @@ services:
       - "9000:9000"
     volumes:
       - sonarqube:/bitnami/sonarqube
+    healthcheck:
+      # if SONARQUBE_SKIP_MIGRATION is set to true, it is recommended to use:
+      #   test: health-check -s DB_MIGRATION_NEEDED -s DB_MIGRATION_RUNNING
+      test: health-check # in normal use
+      start_period: 3m
+      start_interval: 10s
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,13 @@ services:
       - "9000:9000"
     volumes:
       - ./_local/data/sonarqube:/bitnami/sonarqube
+    healthcheck:
+      test: health-check
+      start_period: 3m
+      start_interval: 10s
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
 networks:
   default:

--- a/sonarqube/addons/scripts/health-check
+++ b/sonarqube/addons/scripts/health-check
@@ -12,7 +12,7 @@ Some of the options include:
 
     -s <STATUS>                 Repeat this option to add more valid status. Possible status:
                                   - STARTING: Server initialization is ongoing
-                                  - UP: SonarQube instance is up and running
+                                  - UP: SonarQube instance is up and running (always added as valid)
                                   - DOWN: Instance is up but not running (e.g., due to migration failure)
                                   - RESTARTING: Restart has been requested
                                   - DB_MIGRATION_NEEDED: Database migration required
@@ -21,8 +21,10 @@ Some of the options include:
     -h                          display this help and exit
 
 Example:
+    - $_bin
     - $_bin -u http://my-host:9000/api/system/status
     - $_bin -s STARTING -s RESTARTING
+    - $_bin -s DB_MIGRATION_NEEDED -s DB_MIGRATION_RUNNING
 
 MSG
   exit 2

--- a/sonarqube/addons/scripts/health-check
+++ b/sonarqube/addons/scripts/health-check
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -eo pipefail
+
+_help() {
+  local _bin="${0##*/}"
+  cat 1>&2 <<MSG
+Utility to check if SonarQube is healthy.
+
+Usage: $_bin [options] ...
+Some of the options include:
+    -u <HEALTH_CHECK_URL>       URL used to check the status of SonarQube. (Optional)
+
+    -s <STATUS>                 Repeat this option to add more valid status. Possible status:
+                                  - STARTING: Server initialization is ongoing
+                                  - UP: SonarQube instance is up and running
+                                  - DOWN: Instance is up but not running (e.g., due to migration failure)
+                                  - RESTARTING: Restart has been requested
+                                  - DB_MIGRATION_NEEDED: Database migration required
+                                  - DB_MIGRATION_RUNNING: Database migration in progress
+
+    -h                          display this help and exit
+
+Example:
+    - $_bin -u http://my-host:9000/api/system/status
+    - $_bin -s STARTING -s RESTARTING
+
+MSG
+  exit 2
+}
+
+regex_in() {
+  echo "^($(printf '%s\n' "$@" | tr ' ' '\n' | tr ',' '\n' | tr ';' '\n' | grep . | tr -d ' ' | tr '\n' '|' | rev | cut -d '|' -f2- | rev))\$"
+}
+
+declare -a statuses=(UP)
+health_check_url=""
+while getopts u:s:h opt; do
+  case $opt in
+    u) health_check_url="$OPTARG" ;;
+    s) statuses+=("$OPTARG");;
+    *) _help ;;
+    #...
+  esac
+done
+
+if [ -z "$health_check_url" ]; then
+  . "$ADDONS_HOME/scripts/sonarqube-env.sh"
+  health_check_url="$SONARQUBE_API_URL/system/status"
+fi
+
+result="$(curl -sSfL "$health_check_url" || true)"
+if [ -z "${result:-}" ]; then
+  echo "Couldn't connect to $health_check_url" 1>&2
+  exit 1
+fi
+
+echo "$result"
+status="$(echo "$result" | json_pp 2>/dev/null | grep '"status"' | cut -d '"' -f4 | tr -d '\\n')"
+grep -qE "$(regex_in "${statuses[@]}")" <(echo "$status")

--- a/sonarqube/addons/scripts/post-copy/run.sh
+++ b/sonarqube/addons/scripts/post-copy/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ "$EUID" -ne 0 ]; then
-  echo "Please run as admin"
+if [ ${EUID:-$(id -u)} -ne 0 ]; then
+  echo "Please run this script as root" 1>&2
   exit 1
 fi
 
@@ -15,3 +15,6 @@ ADDONS_PROCESS_STAGE=setup
 . "\$ADDONS_HOME"/scripts/update-settings.sh
 "\$ADDONS_HOME/scripts/migrate.sh"
 MOD
+
+# symlinks for easy access
+ln -sf "$ADDONS_HOME/scripts/health-check" /usr/local/bin/health-check


### PR DESCRIPTION
**Add CLI for SonarQube Health Check**

This pull request adds a new command-line interface (CLI) tool called `health-check` that allows you to verify the health of your SonarQube container. 

The `health-check` tool comes with a built-in help menu (`-h`) that displays the available options and usage instructions. 

```shell
$ health-check -h
Utility to check if SonarQube is healthy.

Usage: health-check [options] ...
Some of the options include:
    -u <HEALTH_CHECK_URL>       URL used to check the status of SonarQube. (Optional)

    -s <STATUS>                 Repeat this option to add more valid status. Possible status:
                                  - STARTING: Server initialization is ongoing
                                  - UP: SonarQube instance is up and running (always added as valid)
                                  - DOWN: Instance is up but not running (e.g., due to migration failure)
                                  - RESTARTING: Restart has been requested
                                  - DB_MIGRATION_NEEDED: Database migration required
                                  - DB_MIGRATION_RUNNING: Database migration in progress

    -h                          display this help and exit

Example:
    - health-check
    - health-check -u http://my-host:9000/api/system/status
    - health-check -s STARTING -s RESTARTING
    - health-check -s DB_MIGRATION_NEEDED -s DB_MIGRATION_RUNNING

```

In contrast to using the HEALTHCHECK directive in the Dockerfile, which would make the health check mandatory, this CLI allows you to manually verify the health of your SonarQube instance when needed. For example, you can use this CLI as part of a Docker Compose configuration to implement a custom health check, as shown below:

```yaml
services:
  sonarqube:
    image: adrianmusante/sonarqube
    # ...
    healthcheck:
      test: health-check
      start_period: 3m
      start_interval: 10s
      interval: 1m
      timeout: 10s
      retries: 3
```

This addition provides a flexible and optional way to verify the health of your SonarQube instance, allowing you to choose when and how you want to check its status.
