### PR TITLE
GitHub rate-limit workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This SonarQube image inherits all environment variables from [Bitnami SonarQube]
 
 ##### sonarqube-community-branch-plugin
 
-- `SONARQUBE_PR_PLUGIN_RESOURCES_URL`: Base URL used to load the images for the PR comments. If the variable is defined as empty the image links are referenced to `sonar.core.serverBaseURL`. Default: `https://cdn.jsdelivr.net/gh/mc1arke/sonarqube-community-branch-plugin@master/src/main/resources/static`
+- `SONARQUBE_PR_PLUGIN_RESOURCES_URL`: Base URL used to load the images for the PR comments. If the variable is defined as empty the image links are referenced to `sonar.core.serverBaseURL`. Default: `https://cdn.jsdelivr.net/gh/mc1arke/sonarqube-community-branch-plugin@<version>/src/main/resources/static`
 
 
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This SonarQube image inherits all environment variables from [Bitnami SonarQube]
 
 ##### sonarqube-community-branch-plugin
 
-- `SONARQUBE_PR_PLUGIN_RESOURCES_URL`: Base URL used to load the images for the PR comments. If the variable is defined as empty the image links are referenced to `sonar.core.serverBaseURL`. Default: `https://raw.githubusercontent.com/mc1arke/sonarqube-community-branch-plugin/master/src/main/resources/static`
+- `SONARQUBE_PR_PLUGIN_RESOURCES_URL`: Base URL used to load the images for the PR comments. If the variable is defined as empty the image links are referenced to `sonar.core.serverBaseURL`. Default: `https://cdn.jsdelivr.net/gh/mc1arke/sonarqube-community-branch-plugin@master/src/main/resources/static`
 
 
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This SonarQube image inherits all environment variables from [Bitnami SonarQube]
 
 ##### sonarqube-community-branch-plugin
 
-- `SONARQUBE_PR_PLUGIN_RESOURCES_URL`: Base URL used to load the images for the PR comments. If the variable is defined as empty the image links are referenced to `sonar.core.serverBaseURL`. Default: `https://cdn.jsdelivr.net/gh/mc1arke/sonarqube-community-branch-plugin@<version>/src/main/resources/static`
+- `SONARQUBE_PR_PLUGIN_RESOURCES_URL`: Base URL used to load the images for the PR comments. If the variable is defined as empty the image links are referenced to `sonar.core.serverBaseURL`. Default: `https://cdn.jsdelivr.net/gh/mc1arke/sonarqube-community-branch-plugin@${SONARQUBE_PR_PLUGIN_VERSION}/src/main/resources/static`
 
 
 

--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -5,7 +5,10 @@ FROM bitnami/sonarqube:$SONARQUBE_VERSION AS base
 USER root
 
 ARG ADDONS_HOME=/opt/addons
-ENV ADDONS_HOME $ADDONS_HOME
+ARG SONARQUBE_PR_PLUGIN_VERSION
+
+ENV ADDONS_HOME=$ADDONS_HOME \
+    SONARQUBE_PR_PLUGIN_VERSION=$SONARQUBE_PR_PLUGIN_VERSION
 
 
 FROM base AS build
@@ -13,7 +16,6 @@ FROM base AS build
 ARG PLUGINS_DIR="$ADDONS_HOME/plugins"
 RUN mkdir -p "$PLUGINS_DIR"
 
-ARG SONARQUBE_PR_PLUGIN_VERSION
 ADD "https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/${SONARQUBE_PR_PLUGIN_VERSION}/sonarqube-community-branch-plugin-${SONARQUBE_PR_PLUGIN_VERSION}.jar" "$PLUGINS_DIR/sonarqube-community-branch-plugin.jar"
 
 COPY addons $ADDONS_HOME

--- a/sonarqube/addons/scripts/sonarqube-env.sh
+++ b/sonarqube/addons/scripts/sonarqube-env.sh
@@ -34,6 +34,6 @@ export SONARQUBE_EMAIL_FROM_NAME="${SONARQUBE_EMAIL_FROM_NAME:-}"
 
 export SONARQUBE_API_URL="http://127.0.0.1:${SONARQUBE_PORT_NUMBER}$(ensure_url $SONARQUBE_WEB_CONTEXT)/api" # only for internal processes
 export SONARQUBE_WEB_URL="$(ensure_url "${SONARQUBE_WEB_URL:-}")"
-[ -v SONARQUBE_PR_PLUGIN_RESOURCES_URL ] || export SONARQUBE_PR_PLUGIN_RESOURCES_URL="https://cdn.jsdelivr.net/gh/mc1arke/sonarqube-community-branch-plugin@master/src/main/resources/static"
+[ -v SONARQUBE_PR_PLUGIN_RESOURCES_URL ] || export SONARQUBE_PR_PLUGIN_RESOURCES_URL="https://cdn.jsdelivr.net/gh/mc1arke/sonarqube-community-branch-plugin@${SONARQUBE_PR_PLUGIN_VERSION:-master}/src/main/resources/static"
 export SONARQUBE_EXTRA_SETTINGS="${SONARQUBE_EXTRA_SETTINGS:-}"
 export SONARQUBE_SKIP_MIGRATION="${SONARQUBE_SKIP_MIGRATION:-no}"

--- a/sonarqube/addons/scripts/sonarqube-env.sh
+++ b/sonarqube/addons/scripts/sonarqube-env.sh
@@ -34,6 +34,6 @@ export SONARQUBE_EMAIL_FROM_NAME="${SONARQUBE_EMAIL_FROM_NAME:-}"
 
 export SONARQUBE_API_URL="http://127.0.0.1:${SONARQUBE_PORT_NUMBER}$(ensure_url $SONARQUBE_WEB_CONTEXT)/api" # only for internal processes
 export SONARQUBE_WEB_URL="$(ensure_url "${SONARQUBE_WEB_URL:-}")"
-[ -v SONARQUBE_PR_PLUGIN_RESOURCES_URL ] || export SONARQUBE_PR_PLUGIN_RESOURCES_URL=https://raw.githubusercontent.com/mc1arke/sonarqube-community-branch-plugin/master/src/main/resources/static
+[ -v SONARQUBE_PR_PLUGIN_RESOURCES_URL ] || export SONARQUBE_PR_PLUGIN_RESOURCES_URL="https://cdn.jsdelivr.net/gh/mc1arke/sonarqube-community-branch-plugin@master/src/main/resources/static"
 export SONARQUBE_EXTRA_SETTINGS="${SONARQUBE_EXTRA_SETTINGS:-}"
 export SONARQUBE_SKIP_MIGRATION="${SONARQUBE_SKIP_MIGRATION:-no}"


### PR DESCRIPTION
This PR implements a workaround for GitHub's new [rate-limiting](https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/) policy by switching the default plugin resources URL from GitHub to a CDN.

The rate-limiting on `raw.githubusercontent.com` was causing failures when loading resources required by the SonarQube analysis. To address this, the plugin resources are now served via [jsDelivr](https://www.jsdelivr.com/), a fast and reliable CDN.

Changes:
- Updated the `SONARQUBE_PR_PLUGIN_RESOURCES_URL` in the SonarQube environment script to point to jsDelivr.
- Adjusted the corresponding default URL in the README documentation.