### PR TITLE
SonarQube v25.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
 SONARQUBE_VERSION=
 LOCAL_DIR=$(PWD)/_local
 DATA_DIR=$(LOCAL_DIR)/data
-BACKUP_DIR=$(LOCAL_DIR)/scripts
+BACKUP_DIR=$(LOCAL_DIR)/backup
 DOCKER_REGISTRY=
 
-extract-scripts:
+extract-files:
 	[ -z "$$SONARQUBE_VERSION" ] && SONARQUBE_VERSION="$$(grep '^ARG SONARQUBE_VERSION=' ./sonarqube/Dockerfile | cut -d '=' -f2)" ; \
 	[ -z "$$SONARQUBE_VERSION" ] && echo "Missing SONARQUBE_VERSION !!" && exit 1; \
 	BACKUP_VERSION_DIR="$(BACKUP_DIR)/$$SONARQUBE_VERSION" && rm -rdf "$$BACKUP_VERSION_DIR" && mkdir -p "$$BACKUP_VERSION_DIR" \
 		&& echo "Extracting scripts to directory: $$BACKUP_VERSION_DIR" \
-		&& docker run --rm --entrypoint= -u "$$(id -u):$$(id -g)" -v "$$BACKUP_VERSION_DIR:/bkp" bitnami/sonarqube:$$SONARQUBE_VERSION cp -Rv /opt/bitnami/scripts/. /bkp
+		&& docker run --rm --entrypoint= -u "$$(id -u):$$(id -g)" -v "$$BACKUP_VERSION_DIR/scripts:/bkp" bitnami/sonarqube:$$SONARQUBE_VERSION cp -Rv /opt/bitnami/scripts/. /bkp \
+		&& docker run --rm --entrypoint= -u "$$(id -u):$$(id -g)" -v "$$BACKUP_VERSION_DIR/sonarqube/web:/bkp" bitnami/sonarqube:$$SONARQUBE_VERSION cp -Rv /opt/bitnami/sonarqube/web/. /bkp \
+		&& echo "Scripts extracted to: $$BACKUP_VERSION_DIR" \
 
 reset-volumes:
 	docker compose down || true; \

--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -1,8 +1,11 @@
-ARG SONARQUBE_VERSION=25.2.0
-ARG SONARQUBE_PR_PLUGIN_VERSION=1.23.0
+ARG SONARQUBE_VERSION=25.4.0
+ARG SONARQUBE_PR_PLUGIN_VERSION=25.4.0
 FROM bitnami/sonarqube:$SONARQUBE_VERSION AS base
 
 USER root
+
+ARG WEB_HOME=/opt/bitnami/sonarqube/web
+ARG WEB_HOME_FILES_LIST=/opt/bitnami/sonarqube/web/files.list
 
 ARG ADDONS_HOME=/opt/addons
 ARG SONARQUBE_PR_PLUGIN_VERSION
@@ -12,6 +15,21 @@ ENV ADDONS_HOME=$ADDONS_HOME \
 
 
 FROM base AS build
+
+RUN set -eux; export DEBIAN_FRONTEND=noninteractive && apt-get update -yq  \
+        && apt-get install -y --no-install-recommends unzip rsync
+
+ARG WORKDIR=/workdir
+WORKDIR "$WORKDIR"
+
+# Sync modified web-app to restore features removed after SonarQube v25.3.0
+# See more: https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/1049
+ADD "https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/${SONARQUBE_PR_PLUGIN_VERSION}/sonarqube-webapp.zip" "${WORKDIR}/sonarqube-webapp.zip"
+RUN unzip -DD -q "$WORKDIR/sonarqube-webapp.zip" -d "$WORKDIR/web" \
+    && rsync -a --checksum --delete "$WORKDIR/web/" "$WEB_HOME/" \
+    && (find "$WEB_HOME" -type f; \
+        echo "$WEB_HOME/WEB-INF/classes/com/sonarsource/branding"; \
+        echo "$WEB_HOME/.htaccess") | sort -u -V >"$WEB_HOME_FILES_LIST"
 
 ARG PLUGINS_DIR="$ADDONS_HOME/plugins"
 RUN mkdir -p "$PLUGINS_DIR"
@@ -26,6 +44,10 @@ RUN cd $ADDONS_HOME \
 
 
 FROM base AS final
+
+COPY --from=build "$WEB_HOME" "$WEB_HOME"
+RUN (find "$WEB_HOME" -type f | grep -v -F -f "$WEB_HOME_FILES_LIST" || echo "No files to delete from $WEB_HOME" 1>&2 ; \
+     echo "$WEB_HOME_FILES_LIST") | xargs -r rm -vf
 
 COPY --from=build $ADDONS_HOME $ADDONS_HOME
 RUN cd $ADDONS_HOME \


### PR DESCRIPTION
### Summary

This PR updates **SonarQube** to version **25.4.0**.

### Details

The Docker image build process has been modified due to the removal of certain components from the SonarQube UI that are required by the [`sonarqube-community-branch-plugin`](https://github.com/mc1arke/sonarqube-community-branch-plugin).

To restore the missing functionality, the web-app now needs to be updated as part of the build process.

More context can be found in the related issue: [mc1arke/sonarqube-community-branch-plugin#1049](https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/1049).
