### PR TITLE
bugfix: jres used by sonar-scanner are restored

### DIFF
--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -96,7 +96,7 @@ RUN set -eux; \
         sed -i 's|PIDDIR=".*"|PIDDIR="\${SONARQUBE_PID_DIR:-\$PWD/pids}"|g' "$f"; \
         sed -i "/^#!.*sh\$/a SONAR_JAVA_PATH=\"$(command -v java)\"" "$f"; \
       done  \
-    && rm -rdf ./jres ./bin/win* ./bin/mac* \
+    && rm -rdf ./bin/win* ./bin/mac* \
     && rm -rdf /tmp/*
 
 COPY rootfs .


### PR DESCRIPTION
This pull request makes a minor update to the `sonarqube/Dockerfile` by adjusting which directories are removed during the build process. Specifically, it no longer deletes the `./jres` directory, which may be needed for runtime or build purposes.

- Dockerfile cleanup:
  * Stopped removing the `./jres` directory during the image build process in `sonarqube/Dockerfile`, potentially preserving required Java runtime files.

## Error

Generated when sonar-scanner (remotely/build process) requests a jre.

```

Caused by: org.sonar.server.exceptions.NotFoundException: Unable to find JRE 'OpenJDK17U-jre_x64_linux_hotspot_17.0.13_11.tar.gz'
        at org.sonar.server.v2.api.analysis.service.JresHandlerImpl.getJreBinary(JresHandlerImpl.java:95)
        at org.sonar.server.v2.api.analysis.controller.DefaultJresController.downloadJre(DefaultJresController.java:48)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:258)
        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:191)
        at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118)
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:991)
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:896)
        at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1089)
        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:979)
        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)
        ... 52 common frames omitted
```